### PR TITLE
Add base-dir option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ git clone git://github.com/fnobi/ejs-cli.git
 ejs-cli "*.ejs" --out dest/ --options options.json 
 ```
 
+
+```bash
+ejs-cli --base-dir src/ "*.ejs" --out dest/
+# renders all of the files in src/ and outputs them to dest/
+```
+
 ```
 cat example.ejs | ejs-cli example.ejs > example.html
 ```

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -20,6 +20,11 @@ var parseOptionsFile = require(__dirname + '/parseOptionsFile');
             .string('f')
             .alias('f', 'file')
             .describe('f', 'give ejs template file path.')
+    
+            .string('b')
+            .alias('b', 'base-dir')
+            .default('b', './')
+            .describe('b', 'base directory that -f is relative to.')
 
             .string('o')
             .alias('o', 'out')
@@ -38,6 +43,7 @@ var parseOptionsFile = require(__dirname + '/parseOptionsFile');
 
     var srcGlob = argv.file || argv._.shift();
     var outDir = argv.out;
+    var baseDir = argv.b;
 
     var verbose = !!outDir; // output log only file output mode.
     function log (tag, msg) {
@@ -53,6 +59,7 @@ var parseOptionsFile = require(__dirname + '/parseOptionsFile');
             if (!/\./.test(srcPath)) {
                 srcPath += '.html';
             }
+            srcPath = srcPath.replace(baseDir, '');
             
             var dest = path.join(outDir, srcPath);
             log('output', '"' + dest + '"');
@@ -94,7 +101,7 @@ var parseOptionsFile = require(__dirname + '/parseOptionsFile');
         return next();
 
     }, function (next) {
-        glob(srcGlob, function (err, array) {
+        glob(path.join(baseDir, srcGlob), function (err, array) {
             if (err) {
                 return next(err);
             }


### PR DESCRIPTION
Thinking about #9, I decided the best way would be to add a `--base-dir` (`-b`) option.

With the directory structure:
```
/
  src
    partials
        footer.ejs
    index.ejs
    page1.ejs
  dist
    index.html
    page1.html
  package.json
```

You would run: 
```
ejs-cli --base-dir src/ "*.ejs" --out dist/
```

With the directory structure:
```
/
  src
    partials
        footer.ejs
    archives
      partials
        oldfooter.ejs
      oldpage1.ejs
    index.ejs
    page1.ejs
  dist
    archives
      oldpage.html
    index.html
    page1.html
  package.json
```
You could do:
```
ejs-cli --base-dir src/ "{!(partials)/,*}*.ejs" --out dest/
```
The glob is rather complicated, but it works!