### PR TITLE
Some useful features I use in my applications

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -20,7 +20,7 @@ var parseOptionsFile = require(__dirname + '/parseOptionsFile');
             .string('f')
             .alias('f', 'file')
             .describe('f', 'give ejs template file path.')
-    
+
             .string('b')
             .alias('b', 'base-dir')
             .default('b', './')
@@ -55,13 +55,7 @@ var parseOptionsFile = require(__dirname + '/parseOptionsFile');
 
     function writeCompiled (result, srcPath, callback) {
         if (outDir) {
-            srcPath = srcPath.replace(/\.ejs$/, '');
-            if (!/\./.test(srcPath)) {
-                srcPath += '.html';
-            }
-            srcPath = srcPath.replace(baseDir, '');
-            
-            var dest = path.join(outDir, srcPath);
+            var dest = path.join(outDir, path.basename(srcPath, '.ejs') + '.html');
             log('output', '"' + dest + '"');
             fs.writeFile(dest, result, { encoding: 'utf8' }, function (err) {
                 callback(err);
@@ -122,7 +116,7 @@ var parseOptionsFile = require(__dirname + '/parseOptionsFile');
                 if (err) {
                     console.log(err);
                 } else {
-                    writeCompiled(result, srcPath, done); 
+                    writeCompiled(result, srcPath, done);
                 }
             });
         }, next);

--- a/lib/parseOptionsFile.js
+++ b/lib/parseOptionsFile.js
@@ -1,9 +1,10 @@
 var async = require('async');
 var fs = require('fs');
+var path = require('path');
 
 var parseOptionsFile = function (filepath, callback) {
     callback = callback || function () {};
-    
+
     var src;
     var options = {};
 
@@ -15,10 +16,15 @@ var parseOptionsFile = function (filepath, callback) {
             return next();
         });
     }, function (next) {
-        fs.readFile(filepath, 'utf8', function (err, body) {
-            src = body;
-            next(err);
-        });
+        if (/\.js$/.test(filepath)) {
+            src = require(path.join(process.cwd(), filepath));
+            next(null);
+        } else {
+            fs.readFile(filepath, 'utf8', function (err, body) {
+                src = body;
+                next(err);
+            });
+        }
     }, function (next) {
         if (/\.json$/.test(filepath)) {
             try {
@@ -26,6 +32,9 @@ var parseOptionsFile = function (filepath, callback) {
             } catch (e) {
                 return next(new Error('fail to parse JSON file.'));
             }
+            return next();
+        } else if (/\.js$/.test(filepath)) {
+            options = src;
             return next();
         }
 


### PR DESCRIPTION
- [x] Use the name of src only, not the whole path

```
ejs client/index.js --o public
```

gives me `public/client/index.html` and it's not expected.

Seems output should point to the dst folder and use the name only from the src one.
- [x] An ability to use js module (requirable) as an input, not only json

Could be useful if the initial data has dynamic content, for instance:

``` js
module.exports = {
  title: 'foo',
  content: fs.readFileSync(...)
}
```
