### PR TITLE
Update cli.js to support dots in filename

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -56,9 +56,7 @@ var parseOptionsFile = require(__dirname + '/parseOptionsFile');
     function writeCompiled (result, srcPath, callback) {
         if (outDir) {
             srcPath = srcPath.replace(/\.ejs$/, '');
-            if (!/\./.test(srcPath)) {
-                srcPath += '.html';
-            }
+            srcPath += '.html';
             srcPath = srcPath.replace(baseDir, '');
             
             var dest = path.join(outDir, srcPath);


### PR DESCRIPTION
Always add the .html extenstion even when there is dot (e.g. main.component.ejs) in the filename.