### PR TITLE
Create directory by mkdirp before fs.writeFile()

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,6 +6,7 @@ var colors = require('colors');
 var async = require('async');
 var ejs = require('ejs');
 var glob = require('glob');
+var mkdirp = require('mkdirp');
 
 var fetchStdio = require(__dirname + '/fetchStdio');
 var parseOptionsFile = require(__dirname + '/parseOptionsFile');
@@ -63,8 +64,14 @@ var parseOptionsFile = require(__dirname + '/parseOptionsFile');
             
             var dest = path.join(outDir, srcPath);
             log('output', '"' + dest + '"');
-            fs.writeFile(dest, result, { encoding: 'utf8' }, function (err) {
-                callback(err);
+            mkdirp(path.dirname(dest), function (err) {
+                if (err) {
+                    return callback(err);
+                }
+
+                fs.writeFile(dest, result, { encoding: 'utf8' }, function (err) {
+                    callback(err);
+                });
             });
         } else {
             log('output', 'STDOUT');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "colors": "~0.6.1",
     "ejs": "2.4.*",
     "async": "~0.2.10",
-    "glob": "~3.2.9"
+    "glob": "~3.2.9",
+    "mkdirp": "^0.5.1"
   },
   "devDependencies": {
     "chai": "~1.6.1",


### PR DESCRIPTION
`--out`オプションで指定したディレクトリが存在しない場合に、以下のようなエラーメッセージが出ていました。

[mkdirp](https://www.npmjs.com/package/mkdirp)を使用して`fs.writeFile()`の前にディレクトリを作成するようにし、ディレクトリが存在しなくてもhtmlファイルが出力されるようにしました。

---

### コマンド
```
$ ejs-cli -b src '**/*.ejs' -o dist
```

### エラーメッセージ
```
{
  Error: ENOENT: no such file or directory, open 'dist/index.html'
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: 'dist/index.html'
}
```

### ディレクトリ構造
```
.
├── dist
│   ├── hoge
│   │   ├── fuga
│   │   │   └── index.html
│   │   └── index.html
│   └── index.html
└── src
    ├── hoge
    │   ├── fuga
    │   │   └── index.ejs
    │   └── index.ejs
    └── index.ejs
```

よろしくお願いします。