### PR TITLE
link from NPM to GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "description": "ejs compile client.",
   "version": "2.1.0",
   "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/fnobi/ejs-cli.git"
+  }
   "scripts": {
     "test": "mocha"
   },


### PR DESCRIPTION
Add metadata so that users get a clickable link from NPM back to the GitHub source.

(Requires a fresh release for change to appear in NPM.)